### PR TITLE
Replace Anuncios with dynamic Escuchar video section

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -277,28 +277,59 @@ nav ul li a:hover::after {
   flex: 1;
 }
 
-/* Announcements Section */
-.announcements {
+/* Escuchar Section */
+.escuchar {
   background-color: var(--dark-bg);
 }
 
-.announcement-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  max-width: 800px;
-  margin: 0 auto;
+.video-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  margin-bottom: 40px;
 }
 
-.announcement-img {
+.video-card {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0;
+}
+
+.video-wrapper {
+  position: relative;
   width: 100%;
-  max-width: 500px;
-  height: auto;
-  object-fit: contain;
-  border-radius: 15px;
-  margin-bottom: 30px;
-  border: 1px solid var(--glass-border);
+  padding-top: 56.25%; /* 16:9 aspect ratio */
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 14px 14px 0 0;
+  border: none;
+}
+
+.video-info {
+  padding: 16px 20px 20px;
+}
+
+.video-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+  line-height: 1.4;
+}
+
+.video-date {
+  font-size: 0.85rem;
+  opacity: 0.6;
+}
+
+.load-more-container {
+  text-align: center;
 }
 
 /* Contact Section */
@@ -365,6 +396,12 @@ footer {
   }
 }
 
+@media (max-width: 992px) and (min-width: 577px) {
+  .video-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 @media (max-width: 768px) {
   .menu-toggle {
     display: flex;
@@ -410,13 +447,8 @@ footer {
     padding: 10px 20px;
   }
   
-  .announcement-img {
-    max-width: 100%;
-    max-height: 250px;
-  }
-  
-  .announcement-card {
-    padding: 15px;
+  .video-grid {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -438,11 +470,7 @@ footer {
     height: 150px;
   }
   
-  .announcement-img {
-    max-height: 200px;
-  }
-  
-  .announcement-card {
-    padding: 10px;
+  .video-grid {
+    gap: 16px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <ul>
           <li><a href="#hero">Inicio</a></li>
           <li><a href="#about">Acerca de</a></li>
-          <li><a href="#announcements">Anuncios</a></li>
+          <li><a href="#escuchar">Escuchar</a></li>
           <li><a href="#contact">Contacto</a></li>
         </ul>
         <div class="menu-toggle">
@@ -69,15 +69,13 @@
     </div>
   </section>
 
-  <!-- Announcements Section -->
-  <section id="announcements" class="announcements">
+  <!-- Escuchar Section -->
+  <section id="escuchar" class="escuchar">
     <div class="container">
-      <h2 class="section-title">Anuncios</h2>
-      <div class="announcement-card glass-card">
-        <img src="assets/fic2.jpeg" alt="Upcoming Event" class="announcement-img">
-        <h3>Próxima noche de adoración</h3>
-        <p>Ven a nuestra noche anual de adoración: Freedom In Christ. Únete a esta experiencia de adoración para celebrar el Dios que nos libertó.</p>
-        <a href="https://www.eventbrite.com/e/freedom-in-christ-tickets-1205690455609?aff=oddtdtcreator&fbclid=IwY2xjawIzPNpleHRuA2FlbQIxMAABHfHC0UudLWdsvGmobYGdjsA7GDvmpHMYmi9HA_g6YQOTwEYsay_qLV3hiA_aem_nQA2wxsT2pXG0Qz0liXffA" class="btn btn-accent">Regístrate</a>
+      <h2 class="section-title">Escuchar</h2>
+      <div id="video-grid" class="video-grid"></div>
+      <div class="load-more-container">
+        <button id="load-more-btn" class="btn btn-accent" style="display:none;">Cargar más</button>
       </div>
     </div>
   </section>

--- a/js/main.js
+++ b/js/main.js
@@ -1,14 +1,14 @@
 // Smooth scrolling for navigation links
 document.addEventListener('DOMContentLoaded', () => {
   const navLinks = document.querySelectorAll('nav a');
-  
+
   navLinks.forEach(link => {
     link.addEventListener('click', function(e) {
       e.preventDefault();
-      
+
       const targetId = this.getAttribute('href').substring(1);
       const targetElement = document.getElementById(targetId);
-      
+
       window.scrollTo({
         top: targetElement.offsetTop - 70, // Offset for fixed header
         behavior: 'smooth'
@@ -19,11 +19,95 @@ document.addEventListener('DOMContentLoaded', () => {
   // Mobile menu toggle
   const menuToggle = document.querySelector('.menu-toggle');
   const navMenu = document.querySelector('nav ul');
-  
+
   if (menuToggle) {
     menuToggle.addEventListener('click', () => {
       navMenu.classList.toggle('active');
       menuToggle.classList.toggle('active');
     });
   }
+
+  // YouTube Escuchar section
+  const CHANNEL_ID = 'UCaCbbzaEdtvnelBl8bu907g';
+  const RSS_URL = `https://www.youtube.com/feeds/videos.xml?channel_id=${CHANNEL_ID}`;
+  const RSS2JSON_URL = `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(RSS_URL)}`;
+
+  let allVideos = [];
+  let displayedCount = 0;
+  const VIDEOS_PER_PAGE = 3;
+
+  async function fetchYouTubeVideos() {
+    try {
+      const response = await fetch(RSS2JSON_URL);
+      const data = await response.json();
+      if (data.status === 'ok') {
+        allVideos = data.items;
+        renderVideos();
+      }
+    } catch (error) {
+      console.error('Error fetching YouTube videos:', error);
+    }
+  }
+
+  function getVideoId(link) {
+    try {
+      const url = new URL(link);
+      const shortsMatch = url.pathname.match(/\/shorts\/([^/?]+)/);
+      if (shortsMatch) return shortsMatch[1];
+      return url.searchParams.get('v');
+    } catch {
+      return null;
+    }
+  }
+
+  function formatDate(dateStr) {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString('es-ES', { year: 'numeric', month: 'long', day: 'numeric' });
+  }
+
+  function renderVideos() {
+    const grid = document.getElementById('video-grid');
+    const loadMoreBtn = document.getElementById('load-more-btn');
+
+    const videosToShow = allVideos.slice(displayedCount, displayedCount + VIDEOS_PER_PAGE);
+
+    videosToShow.forEach(video => {
+      const videoId = getVideoId(video.link);
+      if (!videoId) return;
+
+      const card = document.createElement('div');
+      card.className = 'video-card glass-card';
+      card.innerHTML = `
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed/${videoId}"
+            title="${video.title.replace(/"/g, '&quot;')}"
+            frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen>
+          </iframe>
+        </div>
+        <div class="video-info">
+          <h3 class="video-title">${video.title}</h3>
+          <p class="video-date">${formatDate(video.pubDate)}</p>
+        </div>
+      `;
+      grid.appendChild(card);
+    });
+
+    displayedCount += videosToShow.length;
+
+    if (displayedCount >= allVideos.length) {
+      loadMoreBtn.style.display = 'none';
+    } else {
+      loadMoreBtn.style.display = 'inline-block';
+    }
+  }
+
+  const loadMoreBtn = document.getElementById('load-more-btn');
+  if (loadMoreBtn) {
+    loadMoreBtn.addEventListener('click', renderVideos);
+  }
+
+  fetchYouTubeVideos();
 });


### PR DESCRIPTION
## Changes

- **Replaced static announcements section** with dynamic YouTube video feed from a channel
- **Updated navigation** to link to "Escuchar" instead of "Anuncios"
- **Added video grid layout** with responsive design (3 columns on desktop, 2 on tablet, 1 on mobile)
- **Implemented YouTube API integration** using RSS2JSON to fetch latest videos
- **Added load more functionality** to paginate videos (3 per page)
- **Styled video cards** with embedded YouTube players, titles, and publication dates
- **Updated CSS** with new `.video-grid`, `.video-card`, and `.video-wrapper` classes
- **Added responsive breakpoints** for tablet and mobile views

## Technical Details

- Fetches videos from YouTube channel via RSS feed
- Extracts video IDs from both regular and Shorts links
- Displays videos in embedded iframe format
- Formats publication dates in Spanish (es-ES locale)
- Shows/hides load more button based on available videos