### PR TITLE
Replace navbar text logo with logo.jpeg image

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -135,13 +135,15 @@ header.scrolled {
 }
 
 .logo {
-  font-size: 1.8rem;
-  font-weight: 700;
-  color: var(--light-text);
+  display: flex;
+  align-items: center;
 }
 
-.logo span {
-  color: var(--light-text);
+.logo-img {
+  height: 48px;
+  width: auto;
+  object-fit: contain;
+  border-radius: 4px;
 }
 
 nav ul {

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   <!-- Header -->
   <header>
     <div class="container header-container">
-      <a href="#" class="logo">Rejoice <span>Music</span></a>
+      <a href="#hero" class="logo"><img src="assets/logo.jpeg" alt="Rejoice Music" class="logo-img"></a>
       <nav>
         <ul>
           <li><a href="#hero">Inicio</a></li>


### PR DESCRIPTION
## Summary
- Replaces the "Rejoice Music" text link in the navbar with the `assets/logo.jpeg` image
- Logo links to `#hero` so clicking it scrolls back to the top of the page
- Updates `.logo` CSS to use flex layout; adds `.logo-img` styles (48px height, `object-fit: contain`, subtle border-radius)

## Test plan
- [ ] Logo image renders in the navbar header
- [ ] Clicking the logo scrolls/returns to the hero section
- [ ] Layout looks correct on mobile (hamburger menu still shows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)