### PR TITLE
Add YouTube RSS fallback for Escuchar section

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -357,6 +357,22 @@ nav ul li a:hover::after {
   text-align: center;
 }
 
+.feed-error {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 48px 24px;
+  opacity: 0.7;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.feed-error p {
+  font-size: 1rem;
+  margin: 0;
+}
+
 /* Contact Section */
 .contact {
   background-color: var(--darker-bg);

--- a/js/main.js
+++ b/js/main.js
@@ -37,16 +37,51 @@ document.addEventListener('DOMContentLoaded', () => {
   const VIDEOS_PER_PAGE = 3;
 
   async function fetchYouTubeVideos() {
+    // Primary: rss2json.com
     try {
       const response = await fetch(RSS2JSON_URL);
       const data = await response.json();
-      if (data.status === 'ok') {
+      if (data.status === 'ok' && data.items?.length) {
         allVideos = data.items;
         renderVideos();
+        return;
       }
     } catch (error) {
-      console.error('Error fetching YouTube videos:', error);
+      console.warn('rss2json fetch failed, trying fallback:', error);
     }
+
+    // Fallback: fetch raw YouTube RSS via CORS proxy and parse XML
+    try {
+      const proxyUrl = `https://corsproxy.io/?${encodeURIComponent(RSS_URL)}`;
+      const response = await fetch(proxyUrl);
+      const xmlText = await response.text();
+      const xml = new DOMParser().parseFromString(xmlText, 'text/xml');
+      const entries = Array.from(xml.querySelectorAll('entry'));
+      allVideos = entries.map(entry => ({
+        link: entry.querySelector('link')?.getAttribute('href') || '',
+        title: entry.querySelector('title')?.textContent || '',
+        pubDate: entry.querySelector('published')?.textContent || '',
+      })).filter(v => v.link);
+      if (allVideos.length) {
+        renderVideos();
+        return;
+      }
+    } catch (error) {
+      console.warn('RSS proxy fallback failed:', error);
+    }
+
+    // Final fallback: show error with channel link
+    const grid = document.getElementById('video-grid');
+    const loadMoreBtn = document.getElementById('load-more-btn');
+    if (loadMoreBtn) loadMoreBtn.style.display = 'none';
+    grid.innerHTML = `
+      <div class="feed-error">
+        <p>No pudimos cargar los videos en este momento.</p>
+        <a href="https://www.youtube.com/@rejoicemusicpr" target="_blank" rel="noopener noreferrer" class="btn">
+          Ver en YouTube
+        </a>
+      </div>
+    `;
   }
 
   function getVideoId(link) {


### PR DESCRIPTION
## Summary
- When rss2json.com is down, falls back to fetching the raw YouTube RSS XML via `corsproxy.io` and parsing it client-side with `DOMParser`
- If both sources fail, shows a centered error message ("No pudimos cargar los videos en este momento.") with a "Ver en YouTube" button linking to the channel
- Fallback button styled to match the hero section buttons (glass/pill style, not accent)

## What a reviewer should know
The issue is intermittent — rss2json.com goes down for a few hours at a time and self-recovers. The two-level fallback means visitors always have a path to the content even during outages. No changes to normal behavior when rss2json is healthy.

## Test plan
- [ ] Normal load: videos appear as before via rss2json
- [ ] rss2json down: corsproxy.io fallback loads videos from raw RSS
- [ ] Both down: error UI appears with "Ver en YouTube" button linking to `@rejoicemusicpr`